### PR TITLE
fixed situation when multiple show/hide method calls overlap

### DIFF
--- a/lib/ng4LoadingSpinner.component.ts
+++ b/lib/ng4LoadingSpinner.component.ts
@@ -139,12 +139,23 @@ export class Ng4LoadingSpinnerComponent implements OnInit, OnDestroy {
     this.subscription =
       this.spinnerService.spinnerObservable.subscribe(show => {
         if (show) {
+          if(timer)
+            return;
+
           timer = setTimeout(function () {
+            timer = null;
+
             this.showSpinner = show;
-          }.bind(this), this._threshold);
-        } else {
-          clearTimeout(timer);
-          this.showSpinner = false;
+          }.bind(_this), _this._threshold);
+        }
+        else {
+          if(timer){
+            clearTimeout(timer);
+
+            timer = null;
+          }
+
+          _this.showSpinner = false;
         }
       });
   }


### PR DESCRIPTION
Fixes the following situation:
1. show() is called
2. show() is called again within threshold of 500ms, timer is overwritten with another instance
3. hide() is called again within threshold of the same 500ms, so it cancels the function from the second setTimeout(). At this point hide() can be called any number of times, it doesn't matter
4. The timeout from the first step runs out, function is called and spinner is shown. If one doesn't call hide() after that spinner hangs forever