### PR TITLE
fix error in inlining when file is missing

### DIFF
--- a/tools/gulp/inline-resources.js
+++ b/tools/gulp/inline-resources.js
@@ -80,8 +80,9 @@ function inlineResourcesFromString(content, urlResolver) {
 function inlineTemplate(content, urlResolver) {
   return content.replace(/templateUrl:\s*'([^']+?\.html)'/g, function (m, templateUrl) {
     const templateFile = urlResolver(templateUrl);
+    let templateContent;
     try {
-      const templateContent = fs.readFileSync(templateFile, 'utf-8');
+      templateContent = fs.readFileSync(templateFile, 'utf-8');
     } catch (e) {
       return m;
     }

--- a/tools/gulp/inline-resources.js
+++ b/tools/gulp/inline-resources.js
@@ -80,7 +80,11 @@ function inlineResourcesFromString(content, urlResolver) {
 function inlineTemplate(content, urlResolver) {
   return content.replace(/templateUrl:\s*'([^']+?\.html)'/g, function (m, templateUrl) {
     const templateFile = urlResolver(templateUrl);
-    const templateContent = fs.readFileSync(templateFile, 'utf-8');
+    try {
+      const templateContent = fs.readFileSync(templateFile, 'utf-8');
+    } catch (e) {
+      return m;
+    }
     const shortenedTemplate = templateContent
       .replace(/([\n\r]\s*)+/gm, ' ')
       .replace(/"/g, '\\"');


### PR DESCRIPTION
I encountered an error where `templateUrl: ...` is contained in a comment.
The file that is referenced is missing, since it is not actually used. But the inline-resources.js tries to inline it anyway.
With this I created a quick fix, that just returns the original templateUrl string instead of inlining it.
A better approach would probably be to check if it is enclosed in a comment block.

Just so there is no confusion the comment block I am talking about is not my code, but in an angular core file.