### PR TITLE
Don't timeout unless specifically set

### DIFF
--- a/src/ng4LoadingSpinner.component.ts
+++ b/src/ng4LoadingSpinner.component.ts
@@ -40,7 +40,7 @@ export class Ng4LoadingSpinnerComponent implements OnDestroy {
    * @type {number}
    * @memberof Ng4LoadingSpinnerComponent
    */
-  _timeout = 5000;
+  _timeout = 0;
 
   /**
    * @description Defines z-index property of the loading text
@@ -192,17 +192,19 @@ export class Ng4LoadingSpinnerComponent implements OnDestroy {
           thresholdTimer = setTimeout(function() {
             thresholdTimer = null;
             this.showSpinner = show;
-            timeoutTimer = setTimeout(function() {
-              timeoutTimer = null;
-              this.showSpinner = false;
-            }.bind(this), this.timeout);
+            if (this.timeout !== 0) {
+              timeoutTimer = setTimeout(function() {
+                timeoutTimer = null;
+                this.showSpinner = false;
+              }.bind(this), this.timeout);
+            }
           }.bind(this), this.threshold);
         } else {
           if (thresholdTimer) {
             clearTimeout(thresholdTimer);
             thresholdTimer = null;
           }
-          clearTimeout(timeoutTimer);
+          if (timeoutTimer) clearTimeout(timeoutTimer);
           timeoutTimer = null;
           this.showSpinner = false;
         }


### PR DESCRIPTION
By default, the spinner will timeout at 5 seconds, regardless of when `hide()` is called. This leads to the less-than-optimal workaround of adding an arbitrarily long value for the timeout attribute, e.g. `<ng4-loading-spinner [timeout]="99000"></ng4-loading-spinner>` This proposal makes it so the default is zero, and if zero, will not time out and hide the spinner before `hide()` is called.